### PR TITLE
S-621: Update mx to pass purecap c/c++ flags

### DIFF
--- a/mx.py
+++ b/mx.py
@@ -577,6 +577,7 @@ environment variables:
         self.add_argument('-V', action='store_true', dest='very_verbose', help='enable very verbose output')
         self.add_argument('--no-warning', action='store_false', dest='warn', help='disable warning messages')
         self.add_argument('--quiet', action='store_true', help='disable log messages')
+        self.add_argument('--morello', action='store_true', dest='morello', help='set if running on morello')
         self.add_argument('-y', action='store_const', const='y', dest='answer', help='answer \'y\' to all questions asked')
         self.add_argument('-n', action='store_const', const='n', dest='answer', help='answer \'n\' to all questions asked')
         self.add_argument('-p', '--primary-suite-path', help='set the primary suite directory', metavar='<path>')
@@ -13110,6 +13111,9 @@ _probed_JDKs = {}
 
 def is_quiet():
     return _opts.quiet
+
+def is_morello():
+    return _opts.morello
 
 def _probe_JDK(home):
     res = _probed_JDKs.get(home)

--- a/mx.py
+++ b/mx.py
@@ -13913,13 +13913,13 @@ class JDKConfig(Comparable):
 
         # Prepend the -d64 VM option only if the java command supports it
         try:
-            output = _check_output_str([self.java, '-d64', '-version'], stderr=subprocess.STDOUT)
+            output = _check_output_str([self.java, '-d64','-Xint','-version'], stderr=subprocess.STDOUT)
             self.java_args = ['-d64'] + self.java_args
         except OSError as e:
             raise JDKConfigException(f'{e.errno}: {e.strerror}')
         except subprocess.CalledProcessError as e:
             try:
-                output = _check_output_str([self.java, '-version'], stderr=subprocess.STDOUT)
+                output = _check_output_str([self.java, '-Xint','-version'], stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:
                 raise JDKConfigException(f'{e.returncode}: {e.output}')
 
@@ -13980,7 +13980,7 @@ class JDKConfig(Comparable):
                 while remaining_attempts != 0:
                     remaining_attempts -= 1
                     try:
-                        self._bootclasspath, self._extdirs, self._endorseddirs = [x if x != 'null' else None for x in _check_output_str([self.java, '-cp', _cygpathU2W(binDir), 'ClasspathDump'], stderr=subprocess.PIPE).split('|')]
+                        self._bootclasspath, self._extdirs, self._endorseddirs = [x if x != 'null' else None for x in _check_output_str([self.java, '-Xint','-cp', _cygpathU2W(binDir), 'ClasspathDump'], stderr=subprocess.PIPE).split('|')]
                     except subprocess.CalledProcessError as e:
                         if remaining_attempts == 0:
                             abort(f'{str(e)}{os.linesep}Command output:{e.output}{os.linesep}')
@@ -14054,7 +14054,7 @@ class JDKConfig(Comparable):
         Similar to `OutputCapturingJavaVm.generate_java_command` such that generated commands can be
         retrieved without being executed.
         """
-        return [self.java] + self.processArgs(args, addDefaultArgs=addDefaultArgs)
+        return [self.java, '-Xint'] + self.processArgs(args, addDefaultArgs=addDefaultArgs)
 
     def bootclasspath(self, filtered=True):
         """
@@ -14187,7 +14187,7 @@ class JDKConfig(Comparable):
                 addExportsArg = '--add-exports=java.base/jdk.internal.module=ALL-UNNAMED'
                 _, binDir = _compile_mx_class('ListModules', jdk=self, extraJavacArgs=[addExportsArg])
                 out = LinesOutputCapture()
-                run([self.java, '-cp', _cygpathU2W(binDir), addExportsArg, 'ListModules'], out=out)
+                run([self.java, '-Xint', '-cp', _cygpathU2W(binDir), addExportsArg, 'ListModules'], out=out)
                 lines = out.lines
                 if isJDKImage:
                     for dst, content in [(cache_source, self.home), (cache, '\n'.join(lines))]:

--- a/mx_native.py
+++ b/mx_native.py
@@ -634,6 +634,10 @@ class DefaultNativeProject(NinjaProject):
                 windows=['-MD'],
             ).get(mx.get_os(), ['-fPIC'])
 
+        if mx.is_morello() and self.name != "com.oracle.jvmtiasmagent":
+            default_cflags += ['-O0','-Wshorten-cap-to-int','-Wcheri','-march=morello','-mabi=purecap'
+                                ,'-Xclang','-morello-vararg=new','-mcpu=rainier']
+            
         if mx.is_linux() or mx.is_darwin():
             # Do not leak host paths via dwarf debuginfo
             def add_debug_prefix(prefix_dir):
@@ -656,6 +660,8 @@ class DefaultNativeProject(NinjaProject):
                 darwin=['-dynamiclib', '-undefined', 'dynamic_lookup'],
                 windows=['-dll'],
             ).get(mx.get_os(), ['-shared', '-fPIC'])
+        if mx.is_morello() and self.name != "com.oracle.jvmtiasmagent":
+            default_ldflags += ['-fsanitize=cheri','-Wshorten-cap-to-int','-mabi=purecap','-fuse-ld=lld']
 
         return default_ldflags + super(DefaultNativeProject, self).ldflags
 


### PR DESCRIPTION
# Description
Updated mx so that is passes in c/c++ flags required to compile for purecap.
# Changes
* `--morello` flags has been introduce to mx, which then sets the function `mx.is_morello` to return `true` if it was passed to mx. This behaviour is currently controlled in the [ansible](https://github.com/Soteria-Research/openjdk-ansible/pull/45)
* if `mx.is_morello==true`, then passes the purecap c/c++ flags for compilation of native files.
* added `-Xint` for compilation using morello jdk. Current this does not work due to a jdk [issue](https://github.com/Soteria-Research/morello-jdk17u/issues/257)
# Testing
* can be used to compile Graal-Morello using aarch64-morello-jdk and run on both: aarch64 (success) and morello (fails as expected for this stage).
